### PR TITLE
Enable reading from the remote Toast cache for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           tasks: build check release
           docker_repo: stephanmisc/toast
-          read_remote_cache: ${{ github.event_name == 'push' }}
+          read_remote_cache: true
           write_remote_cache: ${{ github.event_name == 'push' }}
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Enable reading from the remote Toast cache for pull requests.

**Status:** Ready

**Fixes:** N/A