### PR TITLE
Bring back the CI badge with the new URL scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Hashpass: a simple password manager with a twist
 
+[![Build status](https://github.com/stepchowfun/hashpass/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/stepchowfun/hashpass/actions?query=branch%3Amain)
+
 [Hashpass](https://chrome.google.com/webstore/detail/hashpass/gkmegkoiplibopkmieofaaeloldidnko)
 is a password manager which doesn't store any passwords. Instead, it generates
 passwords on the fly using a


### PR DESCRIPTION
Bring back the CI badge with the new URL scheme.

**Status:** Ready

**Fixes:** N/A