### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
       - if: ${{ github.event_name == 'push' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.2.0
         with:
           username: stephanmisc
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -21,7 +21,7 @@ jobs:
           docker_repo: stephanmisc/toast
           read_remote_cache: true
           write_remote_cache: ${{ github.event_name == 'push' }}
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: website/
   deploy_github_pages:
@@ -36,4 +36,4 @@ jobs:
       pages: write
       id-token: write
     steps:
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@v5.0.0


### PR DESCRIPTION
Update pinned GitHub Actions versions to latest:

- `actions/checkout`: v4 → v7.0.0
- `docker/login-action`: v3 → v4.2.0
- `actions/upload-pages-artifact`: v3 → v5.0.0
- `actions/deploy-pages`: v4 → v5.0.0

**Status:** Ready

**Fixes:** N/A