### PR TITLE
Simplify TypeScript build check

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vp dev",
-    "build": "tsc -b && vp build",
+    "build": "tsc --project tsconfig.json && vp build",
     "test": "vp test",
     "lint": "vp check",
     "format": "vp fmt"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.tsbuildinfo",
     "target": "es2023",
     "lib": ["ES2023", "DOM"],
     "module": "esnext",


### PR DESCRIPTION
Use explicit TypeScript project checking before the Vite Plus build, and remove the unused build-info file setting.

**Status:** Ready

**Fixes:** N/A