### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
       - if: ${{ github.event_name == 'push' }}
         uses: docker/login-action@v4.4.0
         with:


### PR DESCRIPTION
Updates actions/checkout 7.0.0 → 7.0.1. Package dependencies, toolchains, submodules, and the 2026 copyright notice were already current.

Upstream release notes were reviewed; no source changes or migrations are required.

**Status:** Ready

**Fixes:** N/A